### PR TITLE
Death animation fully implemented

### DIFF
--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/CrossPlatformDesktopProject.csproj
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/CrossPlatformDesktopProject.csproj
@@ -42,6 +42,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+	<Compile Include="Link\Death.cs" />
     <Compile Include="CollisionHandler\CollisionManager.cs" />
     <Compile Include="Commands\MuteCommand.cs" />
     <Compile Include="Commands\UnlockDoorCommand.cs" />

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Game1.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Game1.cs
@@ -104,6 +104,7 @@ namespace CrossPlatformDesktopProject
             if (player.link_health == 0)
             {
                 Die();
+                player.link_health = -1;
             }
         }
         
@@ -142,6 +143,7 @@ namespace CrossPlatformDesktopProject
         public void Die()
         {
             player.currentState = new Death(player, this, font);
+            SoundStorage.music_instance.Stop();
         }
 
 

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Game1.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Game1.cs
@@ -141,7 +141,7 @@ namespace CrossPlatformDesktopProject
 
         public void Die()
         {
-            this.currentState = new DeathMenuState(this, font);
+            player.currentState = new Death(player, this, font);
         }
 
 

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 using CrossPlatformDesktopProject.GameStates;
+using CrossPlatformDesktopProject.Sound;
 
 namespace CrossPlatformDesktopProject.Link
 {
@@ -19,13 +20,21 @@ namespace CrossPlatformDesktopProject.Link
         private int delay_frame_index;
         private int delay_frames;
         private int times_spun;
+        private int first_frame_change_delay;
+        private int end_game_frames;
+        private int pop_frames;
+        private int blank_frames;
+        private Boolean changed;
+        private Boolean endGame;
 
         private static List<Rectangle> my_source_frames = new List<Rectangle>
         {
             LinkTextureStorage.LINK_IDLE_SOUTH,
             LinkTextureStorage.LINK_IDLE_EAST,
             LinkTextureStorage.LINK_IDLE_NORTH,
-            LinkTextureStorage.MIRRORED_LINK_IDLE_WEST
+            LinkTextureStorage.MIRRORED_LINK_IDLE_WEST,
+            LinkTextureStorage.POP,
+            LinkTextureStorage.BLANK
         };
 
         public Death(Player player, Game1 game, SpriteFont font)
@@ -40,6 +49,12 @@ namespace CrossPlatformDesktopProject.Link
             delay_frame_index = 0;
             delay_frames = 5;
             times_spun = 0;
+            first_frame_change_delay = 60;
+            changed = false;
+            endGame = false;
+            end_game_frames = 120;
+            pop_frames = 60;
+            blank_frames = 70;
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -48,26 +63,52 @@ namespace CrossPlatformDesktopProject.Link
             Rectangle source = my_source_frames[my_frame_index];
             Rectangle destination;
             destination = new Rectangle((int)currentPos.X, (int)currentPos.Y, source.Width, source.Height);
-            //spriteBatch.Draw(texture, destination, source, Color.White);
-            player.DrawSprite(spriteBatch, texture, source);
+            if (my_frame_index == 4)
+            {
+                player.DrawSprite(spriteBatch, texture, source, 4, 4);
+            }
+            else
+            {
+                player.DrawSprite(spriteBatch, texture, source);
+            }
         }
 
         public void Update()
         {
             delay_frame_index++;
-            if (delay_frame_index >= delay_frames)
+            if (delay_frame_index == first_frame_change_delay && !changed)
             {
-                my_frame_index++;
+                changed = true;
                 delay_frame_index = 0;
+                SoundStorage.Instance.getLinkDieSound().Play();
             }
-            if (my_frame_index > 3)
+            if (changed && !endGame)
             {
-                my_frame_index = 0;
-                times_spun++;
+                if (times_spun == 5)
+                {
+                    endGame = true;
+                    my_frame_index = 0;
+                }
+                if (delay_frame_index == delay_frames)
+                {
+                    my_frame_index++;
+                    delay_frame_index = 0;
+                }
+                if (my_frame_index > 3)
+                {
+                    my_frame_index = 0;
+                    times_spun++;
+                }
             }
-            if (times_spun == 4)
+            if (endGame && delay_frame_index == end_game_frames)
             {
                 myGame.currentState = new DeathMenuState(myGame, myFont);
+            } else if (endGame && delay_frame_index == pop_frames)
+            {
+                my_frame_index = 4;
+            } else if (endGame && delay_frame_index == blank_frames)
+            {
+                my_frame_index = 5;
             }
         }
 

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
@@ -3,23 +3,22 @@ using CrossPlatformDesktopProject.Commands;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
+using CrossPlatformDesktopProject.GameStates;
 
 namespace CrossPlatformDesktopProject.Link
 {
-	public class Death
+	public class Death : ILinkState
 	{
         private Player player;
         private Vector2 currentPos;
         private Game1 myGame;
-        private float usedX;
-        private float usedY;
+        private SpriteFont myFont;
+        private float playerX;
+        private float playerY;
         private int my_frame_index;
         private int delay_frame_index;
         private int delay_frames;
-        private int explode_time;
-        private int current_frame;
-        private int swap_frame;
-        private int swap_frame_index;
+        private int times_spun;
 
         private static List<Rectangle> my_source_frames = new List<Rectangle>
         {
@@ -29,9 +28,54 @@ namespace CrossPlatformDesktopProject.Link
             LinkTextureStorage.MIRRORED_LINK_IDLE_WEST
         };
 
-        public Death(Player player, Game1 game)
+        public Death(Player player, Game1 game, SpriteFont font)
 		{
+            this.player = player;
+            this.myGame = game;
+            this.playerX = player.xPos;
+            this.playerY = player.yPos;
+            this.myFont = font;
+            currentPos = new Vector2(playerX, playerY);
+            my_frame_index = 0;
+            delay_frame_index = 0;
+            delay_frames = 5;
+            times_spun = 0;
+        }
 
-		}
-	}
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            Texture2D texture = LinkTextureStorage.Instance.getLinkSpriteSheet();
+            Rectangle source = my_source_frames[my_frame_index];
+            Rectangle destination;
+            destination = new Rectangle((int)currentPos.X, (int)currentPos.Y, source.Width, source.Height);
+            spriteBatch.Draw(texture, destination, source, Color.White);
+        }
+
+        public void Update()
+        {
+            delay_frame_index++;
+            if (delay_frame_index >= delay_frames)
+            {
+                my_frame_index++;
+            }
+            if (my_frame_index > 3)
+            {
+                my_frame_index = 0;
+                times_spun++;
+            }
+            if (times_spun == 4)
+            {
+                myGame.currentState = new DeathMenuState(myGame, myFont);
+            }
+        }
+
+        public void setTextureIndex(int index) { }
+        public void TakeDamage() { }
+        public void MoveUp() { }
+        public void MoveDown() { }
+        public void MoveLeft() { }
+        public void MoveRight() { }
+        public void UsePrimary() { }
+        public void UseSecondary() { }
+    }
 }

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using CrossPlatformDesktopProject.Commands;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+
+namespace CrossPlatformDesktopProject.Link
+{
+	public class Death
+	{
+        private Player player;
+        private Vector2 currentPos;
+        private Game1 myGame;
+        private float usedX;
+        private float usedY;
+        private int my_frame_index;
+        private int delay_frame_index;
+        private int delay_frames;
+        private int explode_time;
+        private int current_frame;
+        private int swap_frame;
+        private int swap_frame_index;
+
+        private static List<Rectangle> my_source_frames = new List<Rectangle>
+        {
+            LinkTextureStorage.LINK_IDLE_SOUTH,
+            LinkTextureStorage.LINK_IDLE_EAST,
+            LinkTextureStorage.LINK_IDLE_NORTH,
+            LinkTextureStorage.MIRRORED_LINK_IDLE_WEST
+        };
+
+        public Death(Player player, Game1 game)
+		{
+
+		}
+	}
+}

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
@@ -48,7 +48,8 @@ namespace CrossPlatformDesktopProject.Link
             Rectangle source = my_source_frames[my_frame_index];
             Rectangle destination;
             destination = new Rectangle((int)currentPos.X, (int)currentPos.Y, source.Width, source.Height);
-            spriteBatch.Draw(texture, destination, source, Color.White);
+            //spriteBatch.Draw(texture, destination, source, Color.White);
+            player.DrawSprite(spriteBatch, texture, source);
         }
 
         public void Update()

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/Death.cs
@@ -57,6 +57,7 @@ namespace CrossPlatformDesktopProject.Link
             if (delay_frame_index >= delay_frames)
             {
                 my_frame_index++;
+                delay_frame_index = 0;
             }
             if (my_frame_index > 3)
             {

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/LinkTextureStorage.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Link/LinkTextureStorage.cs
@@ -135,5 +135,9 @@ namespace CrossPlatformDesktopProject.Link
         public static Rectangle BOMB_EXPLOSION_2 = new Rectangle(155, 185, 16, 16);
         public static Rectangle BOMB_EXPLOSION_3 = new Rectangle(172, 185, 16, 16);
 
+        public static Rectangle POP = new Rectangle(53, 189, 7, 7);
+
+        public static Rectangle BLANK = new Rectangle(260, 260, 16, 16);
+
     }
 }

--- a/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Sound/SoundStorage.cs
+++ b/CrossPlatformDesktopProject/CrossPlatformDesktopProject/Sound/SoundStorage.cs
@@ -32,7 +32,7 @@ namespace CrossPlatformDesktopProject.Sound
         private static SoundEffect EnemyDieSound = null;
         private static SoundEffect LinkHitSound = null;
         private static SoundEffect LinkDieSound = null;
-        private static SoundEffectInstance music_instance = null;
+        public static SoundEffectInstance music_instance = null;
 
 
         private SoundStorage()


### PR DESCRIPTION
New class, Death.cs, created as a Link State class. Link's current state is changed to this class when his health reaches 0, which can be seen in the Update method of Game1.cs which calls the Die() function. I had to set Link's health to -1 to avoid the function being called infinitely. SoundStorage's music_instance had to be made public so that I could stop it when Link dies (thought this would be helpful later as well, if we ever need the music to stop for other sounds). The Death class has 6 rectangles, 1 for each of the directions Link can face, a "pop" rectangle for when Link should pop (could not find it in any of our spritesheets nor any spritesheets online, so I used the boomerang hitting a wall image), and a blank rectangle to draw nothing after the pop occurs. The logic is a bit odd as I had to use a couple of booleans to prevent the game from ending too soon or from getting the wrong indices at the wrong time, but overall it works correctly.

Let me know if there's anything you want changed or added before merging.